### PR TITLE
✨ Feat: 제휴 모집글 이미지 업로드를 S3로 통일

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// AWS S3
+	implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/itzi/itzi/global/config/S3Config.java
+++ b/src/main/java/com/itzi/itzi/global/config/S3Config.java
@@ -1,0 +1,35 @@
+package com.itzi.itzi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/itzi/itzi/global/s3/S3Service.java
+++ b/src/main/java/com/itzi/itzi/global/s3/S3Service.java
@@ -1,0 +1,65 @@
+package com.itzi.itzi.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String bucketName;
+
+    // 이미지 업로드
+    public String upload(MultipartFile file) throws IOException {
+
+        String randomName = UUID.randomUUID().toString();
+        String dirName = "images";
+        String fileName = dirName + "/" + randomName;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+
+        GetUrlRequest request = GetUrlRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        return s3Client.utilities().getUrl(request).toString();
+
+    }
+
+    // 이미지 삭제
+    public void deleteImageUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.isEmpty()) {
+            return;
+        }
+
+        String imageKey = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(imageKey)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+}

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -12,6 +12,7 @@ import com.itzi.itzi.recruitings.dto.response.RecruitingPublishResponse;
 import com.itzi.itzi.recruitings.service.RecruitService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,19 +24,15 @@ public class RecruitingController {
     private final RecruitService recruitService;
 
     // 작성된 기본 정보를 바탕으로 상세 내용 생성
-    @PostMapping("/ai")
+    @PostMapping(value = "/ai")
     public ApiResponse<RecruitingAiGenerateResponse> generateRecruitingAi(
-            @RequestBody RecruitingAiGenerateRequest request
+            @ModelAttribute RecruitingAiGenerateRequest request   // 텍스트 + 파일 동시 바인딩
     ) {
-        Long fixedUserId = 1L; // userId : 항상 1로 고정
-        Type fixedType = Type.RECRUITING; // 항상 RECRUITING 고정
+        Long fixedUserId = 1L;                 // 항상 1
+        Type fixedType = Type.RECRUITING;      // 항상 RECRUITING
 
-        RecruitingAiGenerateResponse response = recruitService.generateRecruitingAi(
-                fixedUserId,
-                fixedType,
-                request.getPostImage(),
-                request
-        );
+        RecruitingAiGenerateResponse response =
+                recruitService.generateRecruitingAi(fixedUserId, fixedType, request);
 
         return ApiResponse.of(SuccessStatus._OK, response);
     }
@@ -43,10 +40,11 @@ public class RecruitingController {
     // 임시 저장
     @PostMapping("/draft")
     public ApiResponse<RecruitingDraftSaveResponse> saveRecruitingDraft(
-            @RequestBody RecruitingDraftSaveRequest request
+            @ModelAttribute RecruitingDraftSaveRequest request
     ) {
         Long fixedUserId = 1L;
         Type fixedType = Type.RECRUITING;
+
 
         RecruitingDraftSaveResponse response =
                 recruitService.saveOrUpdateDraft(fixedUserId, fixedType, request);

--- a/src/main/java/com/itzi/itzi/recruitings/dto/request/RecruitingAiGenerateRequest.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/request/RecruitingAiGenerateRequest.java
@@ -27,18 +27,11 @@ public class RecruitingAiGenerateRequest {
     private String benefit;
     private String condition;
 
-    @Valid
-    private Negotiables negotiables;
+    private Boolean targetNegotiable;
+    private Boolean periodNegotiable;
+    private Boolean benefitNegotiable;
+    private Boolean conditionNegotiable;
 
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class Negotiables {
-        private Boolean target;
-        private Boolean period;
-        private Boolean benefit;
-        private Boolean condition;
-    }
+    private LocalDate exposureEndDate;
 
 }

--- a/src/main/java/com/itzi/itzi/recruitings/dto/request/RecruitingAiGenerateRequest.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/request/RecruitingAiGenerateRequest.java
@@ -3,6 +3,7 @@ package com.itzi.itzi.recruitings.dto.request;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.Valid;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 public class RecruitingAiGenerateRequest {
 
-    private String postImage;
+    private MultipartFile postImage;
     private String title;
     private String target;
 

--- a/src/main/java/com/itzi/itzi/recruitings/dto/request/RecruitingDraftSaveRequest.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/request/RecruitingDraftSaveRequest.java
@@ -2,6 +2,7 @@ package com.itzi.itzi.recruitings.dto.request;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -12,7 +13,7 @@ public class RecruitingDraftSaveRequest {
     // 존재할 경우 해당 DRAFT 글 업데이트, 없으면 생성
     private Long postId;
 
-    private String postImage;
+    private MultipartFile postImage;
     private String title;
     private String target;
 

--- a/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingAiGenerateResponse.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingAiGenerateResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.itzi.itzi.posts.domain.Status;
 import com.itzi.itzi.posts.domain.Type;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,7 +20,7 @@ public class RecruitingAiGenerateResponse {
     private Long userId;
 
     private Type type;              // RECRUITING으로 고정
-    private String postImage;
+    private String postImage;       // Url로 반환
     private String title;
 
     private String target;

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -70,11 +70,11 @@ public class RecruitService {
                         .benefit(request.getBenefit().trim())
                         .condition(request.getCondition().trim())
                         .content(content)
-                        .targetNegotiable(request.getNegotiables() != null && Boolean.TRUE.equals(request.getNegotiables().getTarget()))
-                        .periodNegotiable(request.getNegotiables() != null && Boolean.TRUE.equals(request.getNegotiables().getPeriod()))
-                        .benefitNegotiable(request.getNegotiables() != null && Boolean.TRUE.equals(request.getNegotiables().getBenefit()))
-                        .conditionNegotiable(request.getNegotiables() != null && Boolean.TRUE.equals(request.getNegotiables().getCondition()))
-                        .exposureEndDate(request.getEndDate())                  // 수정 필요
+                        .targetNegotiable(Boolean.TRUE.equals(request.getTargetNegotiable()))
+                        .periodNegotiable(Boolean.TRUE.equals(request.getPeriodNegotiable()))
+                        .benefitNegotiable(Boolean.TRUE.equals(request.getBenefitNegotiable()))
+                        .conditionNegotiable(Boolean.TRUE.equals(request.getConditionNegotiable()))
+                        .exposureEndDate(request.getExposureEndDate())
                         .status(Status.DRAFT)
                         .build();
 
@@ -143,10 +143,10 @@ public class RecruitService {
                 .orElse("00대학교");       // 기본값
 
         // 대상, 기간, 혜택, 조건 협의 가능 문구
-        boolean targetOk = r.getNegotiables() != null && Boolean.TRUE.equals(r.getNegotiables().getTarget());
-        boolean periodOk = r.getNegotiables() != null && Boolean.TRUE.equals(r.getNegotiables().getPeriod());
-        boolean benefitOk = r.getNegotiables() != null && Boolean.TRUE.equals(r.getNegotiables().getBenefit());
-        boolean condOk   = r.getNegotiables() != null && Boolean.TRUE.equals(r.getNegotiables().getCondition());
+        boolean targetOk  = Boolean.TRUE.equals(r.getTargetNegotiable());
+        boolean periodOk  = Boolean.TRUE.equals(r.getPeriodNegotiable());
+        boolean benefitOk = Boolean.TRUE.equals(r.getBenefitNegotiable());
+        boolean condOk    = Boolean.TRUE.equals(r.getConditionNegotiable());
         String periodCondNote = (targetOk || periodOk || benefitOk || condOk ) ? " (대상, 기간, 혜택, 조건 협의 가능)" : "";
 
         return """

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itzi.itzi.global.api.code.ErrorStatus;
 import com.itzi.itzi.global.exception.GeneralException;
+import com.itzi.itzi.global.s3.S3Service;
 import com.itzi.itzi.posts.domain.Post;
 import com.itzi.itzi.posts.domain.Status;
 import com.itzi.itzi.posts.domain.Type;
@@ -19,7 +20,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -36,6 +39,7 @@ import java.util.regex.Pattern;
 public class RecruitService {
 
     private final PostRepository postRepository;
+    private final S3Service s3Service;
 
     @Value("${gemini.api.key}")
     private String apiKey;
@@ -44,7 +48,7 @@ public class RecruitService {
             "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent";
 
 
-    public RecruitingAiGenerateResponse generateRecruitingAi(Long userId, Type type, String postImage, RecruitingAiGenerateRequest request) {
+    public RecruitingAiGenerateResponse generateRecruitingAi(Long userId, Type type, RecruitingAiGenerateRequest request) {
 
         // 1. 검증 : 날짜 역전 금지, 모든 필드 작성
         validate(type, request);
@@ -56,11 +60,9 @@ public class RecruitService {
         String endpoint = GEMINI_ENDPOINT + "?key=" + apiKey;
         String content = callGemini(endpoint, prompt);
 
-        // 4. 결과 저장
-        Post saved = postRepository.save(
-                Post.builder()
+        // 4. 이미지를 제외한 엔티티 구성
+        Post entity = Post.builder()
                         .type(Type.RECRUITING)
-                        .postImage(hasText(postImage) ? postImage.trim() : null)
                         .title(request.getTitle().trim())
                         .target(request.getTarget().trim())
                         .startDate(request.getStartDate())
@@ -74,8 +76,13 @@ public class RecruitService {
                         .conditionNegotiable(request.getNegotiables() != null && Boolean.TRUE.equals(request.getNegotiables().getCondition()))
                         .exposureEndDate(request.getEndDate())                  // 수정 필요
                         .status(Status.DRAFT)
-                        .build()
-        );
+                        .build();
+
+        // 5. 이미지 업로드/변경
+        handleImageUpload(entity, request.getPostImage());
+
+        // 6. 저장
+        Post saved = postRepository.save(entity);
 
         // 5. 응답 DTO
         return RecruitingAiGenerateResponse.builder()
@@ -125,8 +132,9 @@ public class RecruitService {
 
     private String buildPrompt(Type type, RecruitingAiGenerateRequest r) {
 
-        String postImageLine = (r.getPostImage() != null && !r.getPostImage().isBlank())
-                ? "\n(이미지: " + r.getPostImage().trim() + ")"
+        // MultipartFile 기준으로 존재 여부만 판단
+        String postImageLine = (r.getPostImage() != null && !r.getPostImage().isEmpty())
+                ? "\n(이미지 첨부됨)"   // 필요 없다면 "" 로 완전 제거해도 됨
                 : "";
 
         // 제목, 타깃에서 학교명 자동 추출
@@ -301,6 +309,7 @@ public class RecruitService {
 
             // 2) 부분 업데이트(널이면 무시, 값이 있으면 반영)
             applyPatch(entity, request);
+            handleImageUpload(entity, request.getPostImage());
 
         } else {
             // 새 DRAFT 글 생성
@@ -309,6 +318,7 @@ public class RecruitService {
                     .bookmarkCount(0L)
                     .build();
             applyPatch(entity, request);
+            handleImageUpload(entity, request.getPostImage());
         }
 
         // 항상 DRAFT 상태 유지
@@ -326,10 +336,27 @@ public class RecruitService {
         );
     }
 
+    // 이미지 업로드/변경
+    private void handleImageUpload(Post entity, MultipartFile file) {
+        if (file == null || file.isEmpty()) return;
+
+        try {
+            // 기존 이미지가 존재한다면 삭제
+            if (entity.getPostImage() != null && !entity.getPostImage().isBlank()) {
+                s3Service.deleteImageUrl(entity.getPostImage());
+            }
+
+            String uploadUrl = s3Service.upload(file);
+            entity.setPostImage(uploadUrl);
+        } catch (IOException e) {
+            throw new GeneralException(ErrorStatus.INTERNAL_ERROR, "이미지 업로드에 실패했습니다.");
+        }
+    }
+
     // 임시 저장을 하기 위해서는 최소 1개 이상의 필드가 작성돼 있어야 함
     private void validateHasAnyDraftField(RecruitingDraftSaveRequest request) {
         boolean hasAny =
-                hasText(request.getPostImage()) ||
+                request.getPostImage() != null && !request.getPostImage().isEmpty() ||
                 hasText(request.getTitle()) ||
                 hasText(request.getTarget()) ||
                 request.getStartDate() != null || request.getEndDate() != null ||
@@ -350,7 +377,6 @@ public class RecruitService {
 
     // 작성한 부분만 업데이트 (null이면 업데이트 X)
     private void applyPatch(Post e, RecruitingDraftSaveRequest request) {
-        if (hasText(request.getPostImage())) e.setPostImage(request.getPostImage());
         if (hasText(request.getTitle())) e.setTitle(request.getTitle());
         if (hasText(request.getTarget())) e.setTarget(request.getTarget());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,14 @@
     api:
       key: ${GEMINI_API_KEY}
 
+  cloud:
+    aws:
+      s3:
+        bucket-name: itzi-bucket
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+      region:
+        static: ap-northeast-2
+      stack:
+        auto: false


### PR DESCRIPTION
## ✨ Description
> 제휴 모집글 이미지 업로드를 S3로 통일
Fixes #9 

## 📌 구현 내용
- [x] application.yml에 S3 설정 추가
- 자격 증명은 환경변수 연동: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
- [x] S3Config,  S3Service 구현:
- [x] 요청은 파일(MultipartFile), 응답은 S3 URL(String) 로 반환
- [x] 서비스 로직 공통화: handleImageUpload(Post, MultipartFile) 도입
- 파일 있으면 S3 업로드 → 엔티티 postImage에 URL 저장
- 기존 이미지 존재 시 선삭제(!isBlank() 조건) 후 교체
- [x] RecruitingController 수정
- `recruiting/ai,` `/recruiting/draft` 모두 consumes=multipart/form-data 적용
- [x] 협의 가능 항목을 각각의 Boolean 필드로 변경 및 exposureEndDate 매핑 오류 수정