### PR TITLE
✨ Feat: 제휴 게시글 조회

### DIFF
--- a/src/main/java/com/itzi/itzi/posts/domain/OrderBy.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/OrderBy.java
@@ -1,0 +1,10 @@
+package com.itzi.itzi.posts.domain;
+
+// 홈에서 게시물 필터링 기준
+public enum OrderBy {
+    CLOSING,            // exposureEndDate
+    POPULAR,             // bookmarkCount
+    LATEST,             // createdAt DESC
+    OLDEST              // createdAt ASC
+
+}

--- a/src/main/java/com/itzi/itzi/posts/domain/Post.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/Post.java
@@ -85,4 +85,6 @@ public class Post {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    private LocalDateTime publishedAt;
+
 }

--- a/src/main/java/com/itzi/itzi/posts/domain/Post.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/Post.java
@@ -20,6 +20,10 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postId;
 
+    // 추후에 FK로 수정
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "post_type")
     private Type type;

--- a/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
+++ b/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
@@ -1,8 +1,20 @@
 package com.itzi.itzi.posts.repository;
 
 import com.itzi.itzi.posts.domain.Post;
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    // 내 글 + 타입 + 상태 필터
+    List<Post> findByUserIdAndTypeAndStatusIn(
+            Long userId,
+            Type type,
+            Collection<Status> statuses
+    );
 
 }

--- a/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
+++ b/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
@@ -3,8 +3,10 @@ package com.itzi.itzi.posts.repository;
 import com.itzi.itzi.posts.domain.Post;
 import com.itzi.itzi.posts.domain.Status;
 import com.itzi.itzi.posts.domain.Type;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 
@@ -17,8 +19,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             Collection<Status> statuses
     );
 
-    // 모든 사용자가 작성한 제휴 모집글
-    List<Post> findByTypeAndStatus(Type type, Status status);
+    // 모든 사용자가 작성한 제휴 모집글 필터링 조회 : 인기순, 최신순, 오래된순
+    List<Post> findByTypeAndStatus(Type type, Status status, Sort sort);
+
+    // 모든 사용자가 작성한 제휴 모집글 필터링 조회 : 마감 임박순
+    List<Post> findByTypeAndStatusAndExposureEndDateGreaterThanEqual(
+            Type type, Status status, LocalDate today, Sort sort
+    );
 
 
 }

--- a/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
+++ b/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
@@ -17,4 +17,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             Collection<Status> statuses
     );
 
+    // 모든 사용자가 작성한 제휴 모집글
+    List<Post> findByTypeAndStatus(Type type, Status status);
+
+
 }

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -5,14 +5,10 @@ import com.itzi.itzi.global.api.dto.ApiResponse;
 import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.recruitings.dto.request.RecruitingAiGenerateRequest;
 import com.itzi.itzi.recruitings.dto.request.RecruitingDraftSaveRequest;
-import com.itzi.itzi.recruitings.dto.response.RecruitingAiGenerateResponse;
-import com.itzi.itzi.recruitings.dto.response.RecruitingDeleteResponse;
-import com.itzi.itzi.recruitings.dto.response.RecruitingDraftSaveResponse;
-import com.itzi.itzi.recruitings.dto.response.RecruitingPublishResponse;
+import com.itzi.itzi.recruitings.dto.response.*;
 import com.itzi.itzi.recruitings.service.RecruitService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -66,6 +62,14 @@ public class RecruitingController {
     public ApiResponse<RecruitingDeleteResponse> deleteRecruiting(@PathVariable Long postId) {
 
         RecruitingDeleteResponse response = recruitService.deleteRecruiting(postId);
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    // 작성한 게시글 단건 상세 내용 조회
+    @GetMapping("/{postId}")
+    public ApiResponse<RecruitingDetailResponse> getRecruitingDetail(@PathVariable Long postId) {
+
+        RecruitingDetailResponse response = recruitService.getRecruitingDetail(postId);
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -83,4 +83,13 @@ public class RecruitingController {
         List<RecruitingListResponse> response = recruitService.getMyRecruitingList(type);
         return ApiResponse.of(SuccessStatus._OK, response);
     }
+
+    // 모든 사용자가 작성한 제휴 모집글 조회
+    @GetMapping("/all")
+    public ApiResponse<List<RecruitingListResponse>> getAllRecruitingList(
+            @RequestParam(defaultValue = "RECRUITING") Type type
+    ) {
+        List<RecruitingListResponse> responses = recruitService.getAllRecruitingList(type);
+        return ApiResponse.of(SuccessStatus._OK, responses);
+    }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/recruiting")
 @RequiredArgsConstructor
@@ -70,6 +72,15 @@ public class RecruitingController {
     public ApiResponse<RecruitingDetailResponse> getRecruitingDetail(@PathVariable Long postId) {
 
         RecruitingDetailResponse response = recruitService.getRecruitingDetail(postId);
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    // 내가 작성한 게시글 전체 조회 (userId = 1)
+    @GetMapping("/mine")
+    public ApiResponse<List<RecruitingListResponse>> getMyRecruitingList(
+            @RequestParam(defaultValue = "RECRUITING") Type type
+    ) {
+        List<RecruitingListResponse> response = recruitService.getMyRecruitingList(type);
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -2,6 +2,7 @@ package com.itzi.itzi.recruitings.controller;
 
 import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
+import com.itzi.itzi.posts.domain.OrderBy;
 import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.recruitings.dto.request.RecruitingAiGenerateRequest;
 import com.itzi.itzi.recruitings.dto.request.RecruitingDraftSaveRequest;
@@ -87,9 +88,10 @@ public class RecruitingController {
     // 모든 사용자가 작성한 제휴 모집글 조회
     @GetMapping("/all")
     public ApiResponse<List<RecruitingListResponse>> getAllRecruitingList(
-            @RequestParam(defaultValue = "RECRUITING") Type type
+            @RequestParam(defaultValue = "RECRUITING") Type type,
+            @RequestParam(defaultValue = "CLOSING") OrderBy orderBy
     ) {
-        List<RecruitingListResponse> responses = recruitService.getAllRecruitingList(type);
+        List<RecruitingListResponse> responses = recruitService.getAllRecruitingList(type, orderBy);
         return ApiResponse.of(SuccessStatus._OK, responses);
     }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingDetailResponse.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingDetailResponse.java
@@ -1,0 +1,46 @@
+package com.itzi.itzi.recruitings.dto.response;
+
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitingDetailResponse {
+
+    private Long postId;
+    private Long userId;
+
+    private LocalDate exposureEndDate;
+    private Long bookmarkCount;
+
+    // 카테고리 추가 필요
+
+    private Type type;                  // RECRUITING, PROMOTION
+    private Status status;              // DRAFT, PUBLISHED
+
+    private String title;
+    private String postImageUrl;
+    private String target;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String benefit;
+    private String condition;
+
+    private boolean targetNegotiable;
+    private boolean periodNegotiable;
+    private boolean benefitNegotiable;
+    private boolean conditionNegotiable;
+
+    private String content;
+
+    // 작성자 정보 블럭 추가 필요
+
+}

--- a/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingListResponse.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingListResponse.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -16,12 +15,16 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class RecruitingListResponse {
 
-    private Type type;
-
     private Long postId;
     private Long userId;
 
-    private MultipartFile postImageUrl;
+    private Type type;
+    private Status status;
+
+    private LocalDate exposureEndDate;
+    private Long bookmarkCount;
+
+    private String postImageUrl;
     private String title;
     private String target;
     private LocalDate startDate;
@@ -32,8 +35,6 @@ public class RecruitingListResponse {
     private boolean periodNegotiable;
     private boolean benefitNegotiable;
 
-    private Long bookmarkCount;
 
-    private Status status;
 
 }

--- a/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingListResponse.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingListResponse.java
@@ -1,0 +1,39 @@
+package com.itzi.itzi.recruitings.dto.response;
+
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitingListResponse {
+
+    private Type type;
+
+    private Long postId;
+    private Long userId;
+
+    private MultipartFile postImageUrl;
+    private String title;
+    private String target;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String benefit;
+
+    private boolean targetNegotiable;
+    private boolean periodNegotiable;
+    private boolean benefitNegotiable;
+
+    private Long bookmarkCount;
+
+    private Status status;
+
+}

--- a/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingPublishResponse.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingPublishResponse.java
@@ -19,6 +19,6 @@ public class RecruitingPublishResponse {
     private Status status;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "Asia/Seoul")
-    private LocalDateTime createdAt;
+    private LocalDateTime publishedAt;
 
 }

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -424,7 +424,7 @@ public class RecruitService {
 
         // 게시 상태로 변경 및 생성 시간 업데이트
         post.setStatus(Status.PUBLISHED);
-        post.setCreatedAt(LocalDateTime.now());
+        post.setPublishedAt(LocalDateTime.now());
 
         postRepository.save(post);
 
@@ -432,7 +432,7 @@ public class RecruitService {
                 Type.RECRUITING,
                 post.getPostId(),
                 post.getStatus(),
-                post.getCreatedAt()
+                post.getPublishedAt()
         );
     }
 
@@ -528,12 +528,12 @@ public class RecruitService {
 
             case LATEST -> {
                 posts = postRepository.findByTypeAndStatus(
-                        type, status, Sort.by(Sort.Direction.DESC, "createdAt"));
+                        type, status, Sort.by(Sort.Direction.DESC, "publishedAt"));
             }
 
             case OLDEST -> {
                 posts = postRepository.findByTypeAndStatus(
-                        type, status, Sort.by(Sort.Direction.ASC, "createdAt"));
+                        type, status, Sort.by(Sort.Direction.ASC, "publishedAt"));
             }
         }
         return posts.stream().map(this::toListResponse).toList();

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -11,10 +11,7 @@ import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.posts.repository.PostRepository;
 import com.itzi.itzi.recruitings.dto.request.RecruitingAiGenerateRequest;
 import com.itzi.itzi.recruitings.dto.request.RecruitingDraftSaveRequest;
-import com.itzi.itzi.recruitings.dto.response.RecruitingAiGenerateResponse;
-import com.itzi.itzi.recruitings.dto.response.RecruitingDeleteResponse;
-import com.itzi.itzi.recruitings.dto.response.RecruitingDraftSaveResponse;
-import com.itzi.itzi.recruitings.dto.response.RecruitingPublishResponse;
+import com.itzi.itzi.recruitings.dto.response.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -456,5 +453,35 @@ public class RecruitService {
                 post.getPostId(),
                 post.getStatus()
         );
+    }
+
+    // 작성한 게시글 단건 상세 내용 조회
+    @Transactional(readOnly = true)
+    public RecruitingDetailResponse getRecruitingDetail(Long postId) {
+
+        // 존재하는 게시글인지 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        return RecruitingDetailResponse.builder()
+                .userId(1L)                     // userId는 1로 고정
+                .postId(post.getPostId())
+                .type(post.getType())
+                .status(post.getStatus())
+                .exposureEndDate(post.getExposureEndDate())
+                .bookmarkCount(post.getBookmarkCount())
+                .title(post.getTitle())
+                .target(post.getTarget())
+                .targetNegotiable(post.isTargetNegotiable())
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
+                .periodNegotiable(post.isPeriodNegotiable())
+                .benefit(post.getBenefit())
+                .benefitNegotiable(post.isBenefitNegotiable())
+                .condition(post.getCondition())
+                .conditionNegotiable(post.isConditionNegotiable())
+                .postImageUrl(post.getPostImage())
+                .content(post.getContent())
+                .build();
     }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -26,6 +26,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -482,6 +483,38 @@ public class RecruitService {
                 .conditionNegotiable(post.isConditionNegotiable())
                 .postImageUrl(post.getPostImage())
                 .content(post.getContent())
+                .build();
+    }
+
+    // 내가 작성한 게시글 전체 리스트 조회 (userId = 1 고정)
+    @Transactional(readOnly = true)
+    public List<RecruitingListResponse> getMyRecruitingList(Type type) {
+        Long FIXED_USER_ID = 1L;
+        List<Status> statuses = List.of(Status.DRAFT, Status.PUBLISHED);
+
+        return postRepository.findByUserIdAndTypeAndStatusIn(FIXED_USER_ID, type, statuses)
+                .stream()
+                .map(this::toListResponse)
+                .toList();
+    }
+
+    private RecruitingListResponse toListResponse(Post post) {
+        return RecruitingListResponse.builder()
+                .postId(post.getPostId())
+                .userId(post.getUserId())
+                .type(post.getType())
+                .status(post.getStatus())
+                .exposureEndDate(post.getExposureEndDate())
+                .bookmarkCount(post.getBookmarkCount())
+                .postImageUrl(post.getPostImage())
+                .title(post.getTitle())
+                .target(post.getTarget())
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
+                .benefit(post.getBenefit())
+                .targetNegotiable(post.isTargetNegotiable())
+                .periodNegotiable(post.isPeriodNegotiable())
+                .benefitNegotiable(post.isBenefitNegotiable())
                 .build();
     }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -498,6 +498,18 @@ public class RecruitService {
                 .toList();
     }
 
+    // 모든 사용자가 작성한 제휴 모집글 조회
+    @Transactional(readOnly = true)
+    public List<RecruitingListResponse> getAllRecruitingList(Type type) {
+        Status status = Status.PUBLISHED;           // 게시된 게시물만 조회
+
+        return postRepository.findByTypeAndStatus(type, status)
+                .stream()
+                .map(this::toListResponse)
+                .toList();
+    }
+
+
     private RecruitingListResponse toListResponse(Post post) {
         return RecruitingListResponse.builder()
                 .postId(post.getPostId())


### PR DESCRIPTION
## ✨ Description
> 제휴 게시글 조회
Fixes #8 

## 📌 구현 내용

- [x] 내 글 목록: GET `/recruiting/mine?type=RECRUITING`
- post 엔티티에 userId 컬럼 추가
- userId는 1로 고정
- [x] 내 글 상세: GET `/recruiting/{postId}`
- status가 DRAFT, PUBLISHED일 경우 조회
- [x] 모든 사용자가 작성한 게시글 조회 구현 GET `/recruiting/all?type=RECRUITING` (status : `PUBLISHED`)
- [x] 모든 사용자가 작성한 게시글 필터링 조회 구현 
- 마감임박순 / 최신순 / 오래된순 / 인기순

### 참고 사항
- 모든 사용자가 작성한 게시글 조회는 추후에 **category** 필터링 추가 구현 필요
- 제휴 게시글 단건 상세 조회 기능에 **매장/사용자** 정보 추가 필요