### PR TITLE
✨ Feat: 제휴 게시글 조회

### DIFF
--- a/src/main/java/com/itzi/itzi/posts/domain/OrderBy.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/OrderBy.java
@@ -4,7 +4,7 @@ package com.itzi.itzi.posts.domain;
 public enum OrderBy {
     CLOSING,            // exposureEndDate
     POPULAR,             // bookmarkCount
-    LATEST,             // createdAt DESC
-    OLDEST              // createdAt ASC
+    LATEST,             // publishedAt DESC
+    OLDEST              // publishedAt ASC
 
 }

--- a/src/main/java/com/itzi/itzi/posts/domain/Post.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/Post.java
@@ -87,4 +87,8 @@ public class Post {
 
     private LocalDateTime publishedAt;
 
+    // 제휴 제안자, 대상자
+    private Boolean exposeProposerInfo;
+    private Boolean exposeTargetInfo;
+
 }

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -2,7 +2,9 @@ package com.itzi.itzi.promotion.controller;
 
 import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
+import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
+import com.itzi.itzi.promotion.dto.response.PromotionDraftSaveResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
 import com.itzi.itzi.promotion.service.PromotionService;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,17 @@ public class PromotionController {
 
         Long fixedUserId = 1L;                 // 항상 1
         PromotionManualPublishResponse response = promotionService.promotionManualPublish(fixedUserId, request);
+
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    // 제휴 게시글 임시 저장
+    @PostMapping("/draft")
+    public ApiResponse<PromotionDraftSaveResponse> promotionDraft(
+            @ModelAttribute PromotionDraftSaveRequest request
+    ) {
+        Long fixedUserId = 1L;
+        PromotionDraftSaveResponse response = promotionService.promotionDraft(fixedUserId, request);
 
         return ApiResponse.of(SuccessStatus._OK, response);
     }

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -4,6 +4,7 @@ import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
 import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
+import com.itzi.itzi.promotion.dto.response.PromotionDeleteResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionDraftSaveResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionEditViewResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
@@ -61,6 +62,15 @@ public class PromotionController {
         Long fixedUserId = 1L;                 // 항상 1
         PromotionManualPublishResponse response = promotionService.republish(fixedUserId, postId, request);
 
+        return ApiResponse.of(SuccessStatus._OK, response);
+
+    }
+
+    // 게시물 삭제하기
+    @DeleteMapping("/{postId}")
+    public ApiResponse<PromotionDeleteResponse> delete(@PathVariable Long postId) {
+
+        PromotionDeleteResponse response = promotionService.delete(postId);
         return ApiResponse.of(SuccessStatus._OK, response);
 
     }

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -1,0 +1,34 @@
+package com.itzi.itzi.promotion.controller;
+
+import com.itzi.itzi.global.api.code.SuccessStatus;
+import com.itzi.itzi.global.api.dto.ApiResponse;
+import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
+import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
+import com.itzi.itzi.promotion.service.PromotionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/promotion")
+@RequiredArgsConstructor
+@Slf4j
+public class PromotionController {
+
+    private final PromotionService promotionService;
+
+    // 제휴 게시글 수동 작성 후 업로드
+    @PostMapping
+    public ApiResponse<PromotionManualPublishResponse> promotionManualPublish(
+            @ModelAttribute PromotionManualPublishRequest request
+    ){
+
+        Long fixedUserId = 1L;                 // 항상 1
+        PromotionManualPublishResponse response = promotionService.promotionManualPublish(fixedUserId, request);
+
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+}

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -4,10 +4,7 @@ import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
 import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
-import com.itzi.itzi.promotion.dto.response.PromotionDeleteResponse;
-import com.itzi.itzi.promotion.dto.response.PromotionDraftSaveResponse;
-import com.itzi.itzi.promotion.dto.response.PromotionEditViewResponse;
-import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
+import com.itzi.itzi.promotion.dto.response.*;
 import com.itzi.itzi.promotion.service.PromotionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +38,13 @@ public class PromotionController {
         Long fixedUserId = 1L;
         PromotionDraftSaveResponse response = promotionService.promotionDraft(fixedUserId, request);
 
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    // 제휴 게시글 업로드
+    @PatchMapping("{postId}/publish")
+    public ApiResponse<PromotionPublishResponse> publish(@PathVariable Long postId ) {
+        PromotionPublishResponse response = promotionService.publish(postId);
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -5,14 +5,12 @@ import com.itzi.itzi.global.api.dto.ApiResponse;
 import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
 import com.itzi.itzi.promotion.dto.response.PromotionDraftSaveResponse;
+import com.itzi.itzi.promotion.dto.response.PromotionEditViewResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
 import com.itzi.itzi.promotion.service.PromotionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/promotion")
@@ -44,4 +42,27 @@ public class PromotionController {
 
         return ApiResponse.of(SuccessStatus._OK, response);
     }
+
+    // 재수정 진입 (작성된 글 조회)
+    @GetMapping("/{postId}/edit")
+    public ApiResponse<PromotionEditViewResponse> getEditView(
+            @PathVariable Long postId) {
+        PromotionEditViewResponse response = promotionService.getEditView(postId);
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    // 재수정 후 즉시 게시
+    @PatchMapping("/{postId}/republish")
+    public ApiResponse<PromotionManualPublishResponse> republish(
+            @PathVariable Long postId,
+            @ModelAttribute PromotionManualPublishRequest request
+    ) {
+
+        Long fixedUserId = 1L;                 // 항상 1
+        PromotionManualPublishResponse response = promotionService.republish(fixedUserId, postId, request);
+
+        return ApiResponse.of(SuccessStatus._OK, response);
+
+    }
+
 }

--- a/src/main/java/com/itzi/itzi/promotion/dto/request/PromotionDraftSaveRequest.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/request/PromotionDraftSaveRequest.java
@@ -1,0 +1,33 @@
+package com.itzi.itzi.promotion.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class PromotionDraftSaveRequest {
+
+    // 존재할 경우 해당 DRAFT 글 업데이트, 없으면 생성
+    private Long postId;
+
+    private MultipartFile postImage;
+    private String title;
+    private String target;
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    private String benefit;
+    private String condition;
+    private String content;
+
+    private LocalDate exposureEndDate;
+
+    private Boolean exposeProposerInfo;
+    private Boolean exposeTargetInfo;
+
+
+}

--- a/src/main/java/com/itzi/itzi/promotion/dto/request/PromotionManualPublishRequest.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/request/PromotionManualPublishRequest.java
@@ -1,0 +1,26 @@
+package com.itzi.itzi.promotion.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class PromotionManualPublishRequest {
+
+
+    private MultipartFile postImage;
+    private String title;
+    private String target;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String benefit;
+    private String condition;
+    private String content;
+    private LocalDate exposureEndDate;
+
+    private Boolean exposeProposerInfo;
+    private Boolean exposeTargetInfo;
+}

--- a/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionDeleteResponse.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionDeleteResponse.java
@@ -1,0 +1,18 @@
+package com.itzi.itzi.promotion.dto.response;
+
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PromotionDeleteResponse {
+
+    private Long postId;
+    private Type type;
+    private Status status;
+
+}

--- a/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionDraftSaveResponse.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionDraftSaveResponse.java
@@ -1,0 +1,24 @@
+package com.itzi.itzi.promotion.dto.response;
+
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PromotionDraftSaveResponse {
+
+    private Long postId;
+    private Long userId;
+
+    private Type type;                  // PROMOTION
+    private Status status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionEditViewResponse.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionEditViewResponse.java
@@ -1,0 +1,30 @@
+package com.itzi.itzi.promotion.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionEditViewResponse {
+
+    private Long postId;
+    private String postImage;
+
+    private String title;
+    private String target;
+    private String benefit;
+    private String condition;
+    private String content;
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalDate exposureEndDate;
+
+    private Boolean exposeProposerInfo;
+    private Boolean exposeTargetInfo;
+
+}

--- a/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionManualPublishResponse.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionManualPublishResponse.java
@@ -1,0 +1,36 @@
+package com.itzi.itzi.promotion.dto.response;
+
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionManualPublishResponse {
+
+    private Type type;
+    private Status status;
+    private Long postId;
+
+    private String postImage;
+    private String title;
+    private String target;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String benefit;
+    private String condition;
+    private String content;
+    private LocalDate exposureEndDate;
+
+    private Boolean exposeProposerInfo;
+    private Boolean exposeTargetInfo;
+
+    private LocalDateTime publishedAt;
+}

--- a/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionPublishResponse.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionPublishResponse.java
@@ -1,0 +1,21 @@
+package com.itzi.itzi.promotion.dto.response;
+
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionPublishResponse {
+
+    private Type type;
+    private Status status;
+    private Long postId;
+    private LocalDateTime publishedAt;
+
+}

--- a/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
@@ -7,18 +7,21 @@ import com.itzi.itzi.posts.domain.Post;
 import com.itzi.itzi.posts.domain.Status;
 import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.posts.repository.PostRepository;
+import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
+import com.itzi.itzi.promotion.dto.response.PromotionDraftSaveResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import static org.springframework.util.StringUtils.hasText;
 
 @Service
 @Slf4j
@@ -81,13 +84,68 @@ public class PromotionService {
 
     }
 
+    // 제휴 게시글 임시 저장
+    @Transactional
+    public PromotionDraftSaveResponse promotionDraft(Long userId, PromotionDraftSaveRequest request) {
+
+        // 0. 제휴 게시글을 맺을 수 있는 상태인지 검증 추가 필요
+
+        // 1. 필수 값 검증
+        validateHasAnyDraftField(request);
+
+        // 2. 날짜 역전 검증
+        validateOptionalDateRange(request.getStartDate(), request.getEndDate());
+
+        Post post;
+
+        if (request.getPostId() != null) {
+            post = postRepository.findById(request.getPostId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND, "존재하지 않는 postId입니다."));
+
+            // status가 DRAFT일 경우에만 임시 저장 가능
+            if (post.getStatus() != Status.DRAFT) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "임시 저장은 DRAFT 상태의 게시글만 가능합니다.");
+
+            }
+
+            // 수정, 새로 작성된 부분만 업데이트
+            applyPatch(post, request);
+            handleImageUpload(post, request.getPostImage());
+        } else {
+            // 새 제휴 게시글 생성
+            post = Post.builder()
+                    .status(Status.DRAFT)
+                    .userId(userId)
+                    .type(Type.PROMOTION)
+                    .build();
+
+            applyPatch(post, request);
+            handleImageUpload(post, request.getPostImage());
+        }
+
+        if (post.getType() == null) {
+            post.setType(Type.PROMOTION);
+        }
+
+        Post saved = postRepository.save(post);
+
+        return new PromotionDraftSaveResponse(
+                saved.getPostId(),
+                userId,
+                Type.PROMOTION,
+                saved.getStatus(),
+                saved.getCreatedAt(),
+                saved.getUpdatedAt()
+        );
+    }
+
     // 필수값 검증
     private void validateForPublish(PromotionManualPublishRequest request) {
-        if (!StringUtils.hasText(request.getTitle())
-            || !StringUtils.hasText(request.getTarget())
-            || !StringUtils.hasText(request.getBenefit())
-            || !StringUtils.hasText(request.getCondition())
-            || !StringUtils.hasText(request.getContent())
+        if (!hasText(request.getTitle())
+            || !hasText(request.getTarget())
+            || !hasText(request.getBenefit())
+            || !hasText(request.getCondition())
+            || !hasText(request.getContent())
             || request.getStartDate() == null || request.getEndDate() == null
             || request.getExposureEndDate() == null ){
 
@@ -104,6 +162,46 @@ public class PromotionService {
 
         if (end.isBefore(start)) {
             throw new GeneralException(ErrorStatus.DATE_RANGE_INVALID);
+        }
+    }
+
+    // 임시 저장을 위해서는 최소 1개 이상의 필드가 작성돼야 함
+    private void validateHasAnyDraftField(PromotionDraftSaveRequest request) {
+        boolean hasAny =
+                request.getPostImage() != null && !request.getPostImage().isEmpty() ||
+                        hasText(request.getTitle()) ||
+                        hasText(request.getTarget())||
+                request.getStartDate() != null || request.getEndDate() != null ||
+                hasText(request.getBenefit()) || hasText(request.getCondition()) ||
+                hasText(request.getContent()) || request.getExposureEndDate() != null ||
+                Boolean.TRUE.equals(request.getExposeProposerInfo()) ||
+                Boolean.TRUE.equals(request.getExposeTargetInfo());
+
+        if (!hasAny) {
+            throw new GeneralException(ErrorStatus.REQUIRED_FIELD_MISSING, "임시 저장을 위해서는 1개 이상의 필드가 필요합니다.");
+        }
+
+    }
+
+    // 작성한 부분만 업데이트
+    private void applyPatch(Post post, PromotionDraftSaveRequest request) {
+        if (hasText(request.getTitle())) post.setTitle(request.getTitle());
+        if (hasText(request.getTarget())) post.setTarget(request.getTarget());
+        if (hasText(request.getBenefit())) post.setBenefit(request.getBenefit());
+        if (hasText(request.getCondition())) post.setCondition(request.getCondition());
+        if (hasText(request.getContent())) post.setContent(request.getContent());
+
+        if (request.getStartDate() != null) post.setStartDate(request.getStartDate());
+        if (request.getEndDate() != null) post.setEndDate(request.getEndDate());
+        if (request.getExposureEndDate() != null) post.setExposureEndDate(request.getExposureEndDate());
+
+        if (request.getExposeProposerInfo() != null) post.setExposeProposerInfo(request.getExposeProposerInfo());
+        if (request.getExposeTargetInfo() != null) post.setExposeTargetInfo(request.getExposeTargetInfo());
+    }
+
+    private void validateOptionalDateRange(LocalDate start, LocalDate end) {
+        if (start != null && end != null && end.isBefore(start)) {
+            throw new GeneralException(ErrorStatus.DATE_RANGE_INVALID, "종료일이 시작일보다 빠릅니다.");
         }
     }
 

--- a/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
@@ -1,0 +1,127 @@
+package com.itzi.itzi.promotion.service;
+
+import com.itzi.itzi.global.api.code.ErrorStatus;
+import com.itzi.itzi.global.exception.GeneralException;
+import com.itzi.itzi.global.s3.S3Service;
+import com.itzi.itzi.posts.domain.Post;
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import com.itzi.itzi.posts.repository.PostRepository;
+import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
+import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PromotionService {
+
+    private final PostRepository postRepository;
+    private final S3Service s3Service;
+
+    // 제휴 게시글 수동 작성 후 업로드
+    @Transactional
+    public PromotionManualPublishResponse promotionManualPublish(Long userId, PromotionManualPublishRequest request) {
+
+        // 0. 제휴 게시글을 맺을 수 있는 상태인지 검증 추가 필요
+
+        // 1. 필수 값 검증
+        validateForPublish(request);
+
+        // 2. 엔티티 생성 및 저장
+        Post post = Post.builder()
+                .type(Type.PROMOTION)
+                .status(Status.PUBLISHED)
+                .userId(userId)
+                .title(request.getTitle())
+                .target(request.getTarget())
+                .benefit(request.getBenefit())
+                .condition(request.getCondition())
+                .content(request.getContent())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .exposureEndDate(request.getExposureEndDate())
+                .exposeProposerInfo(Boolean.TRUE.equals(request.getExposeProposerInfo()))
+                .exposeTargetInfo(Boolean.TRUE.equals(request.getExposeTargetInfo()))
+                .publishedAt(LocalDateTime.now())
+                .build();
+
+        // 3. 이미지 업로드
+        handleImageUpload(post, request.getPostImage());
+
+        postRepository.save(post);
+
+        // 4. 응답 반환
+        return PromotionManualPublishResponse.builder()
+                .type(post.getType())
+                .status(post.getStatus())
+                .postId(post.getPostId())
+                .postImage(post.getPostImage())
+                .title(post.getTitle())
+                .target(post.getTarget())
+                .benefit(post.getBenefit())
+                .condition(post.getCondition())
+                .content(post.getContent())
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
+                .exposureEndDate(post.getExposureEndDate())
+                .exposeProposerInfo(post.getExposeProposerInfo())
+                .exposeTargetInfo(post.getExposeTargetInfo())
+                .publishedAt(post.getPublishedAt())
+                .build();
+
+    }
+
+    // 필수값 검증
+    private void validateForPublish(PromotionManualPublishRequest request) {
+        if (!StringUtils.hasText(request.getTitle())
+            || !StringUtils.hasText(request.getTarget())
+            || !StringUtils.hasText(request.getBenefit())
+            || !StringUtils.hasText(request.getCondition())
+            || !StringUtils.hasText(request.getContent())
+            || request.getStartDate() == null || request.getEndDate() == null
+            || request.getExposureEndDate() == null ){
+
+            throw new GeneralException(ErrorStatus.REQUIRED_FIELD_MISSING);
+        }
+
+        // 이미지 필수 검증
+        if (request.getPostImage() == null || request.getPostImage().isEmpty()) {
+            throw new GeneralException(ErrorStatus.REQUIRED_FIELD_MISSING, "이미지는 필수입니다.");
+        }
+
+        LocalDate start = request.getStartDate();
+        LocalDate end = request.getEndDate();
+
+        if (end.isBefore(start)) {
+            throw new GeneralException(ErrorStatus.DATE_RANGE_INVALID);
+        }
+    }
+
+    // 이미지 업로드/변경
+    private void handleImageUpload(Post entity, MultipartFile file) {
+        if (file == null || file.isEmpty()) return;
+
+        try {
+            // 기존 이미지가 존재한다면 삭제
+            if (entity.getPostImage() != null && !entity.getPostImage().isBlank()) {
+                s3Service.deleteImageUrl(entity.getPostImage());
+            }
+
+            String uploadUrl = s3Service.upload(file);
+            entity.setPostImage(uploadUrl);
+        } catch (IOException e) {
+            throw new GeneralException(ErrorStatus.INTERNAL_ERROR, "이미지 업로드에 실패했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
@@ -10,6 +10,7 @@ import com.itzi.itzi.posts.repository.PostRepository;
 import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
 import com.itzi.itzi.promotion.dto.response.PromotionDraftSaveResponse;
+import com.itzi.itzi.promotion.dto.response.PromotionEditViewResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -139,6 +140,82 @@ public class PromotionService {
         );
     }
 
+    // 재수정 진입 (작성된 값이 화면에 조회)
+    @Transactional(readOnly = true)
+    public PromotionEditViewResponse getEditView(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        if (post.getStatus() != Status.PUBLISHED) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "게시된 게시물만 수정 가능합니다.");
+        }
+
+        return PromotionEditViewResponse.builder()
+                .postId(post.getPostId())
+                .postImage(post.getPostImage())
+                .title(post.getTitle())
+                .target(post.getTarget())
+                .benefit(post.getBenefit())
+                .condition(post.getCondition())
+                .content(post.getContent())
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
+                .exposureEndDate(post.getExposureEndDate())
+                .exposeProposerInfo(post.getExposeProposerInfo())
+                .exposeTargetInfo(post.getExposeTargetInfo())
+                .build();
+    }
+
+    // 재수정 후 즉시 게시
+    @Transactional
+    public PromotionManualPublishResponse republish(Long userId, Long postId, PromotionManualPublishRequest request) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        if (post.getStatus() != Status.PUBLISHED) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "게시된 글만 재수정 가능합니다.");
+        }
+
+        // 1. 수정된 값 반영
+        applyPatch(post, request);
+
+        // 2. 이미지가 변경된 경우 교체
+        if (request.getPostImage() != null && !request.getPostImage().isEmpty()) {
+            handleImageUpload(post, request.getPostImage());
+        }
+
+        // 3. 게시 요건 검증 (모든 필드가 작성되어야 함)
+        validateForPublishEntity(post);
+
+        // 4. 재게시
+        post.setType(post.getType() == null ? Type.PROMOTION : post.getType());
+        post.setPublishedAt(LocalDateTime.now());
+
+        Post saved = postRepository.save(post);
+        return buildPublishResponse(saved);
+    }
+
+    private PromotionManualPublishResponse buildPublishResponse(Post saved) {
+        return PromotionManualPublishResponse.builder()
+                .type(saved.getType())
+                .status(saved.getStatus())
+                .postId(saved.getPostId())
+                .postImage(saved.getPostImage())
+                .title(saved.getTitle())
+                .target(saved.getTarget())
+                .benefit(saved.getBenefit())
+                .condition(saved.getCondition())
+                .content(saved.getContent())
+                .startDate(saved.getStartDate())
+                .endDate(saved.getEndDate())
+                .exposureEndDate(saved.getExposureEndDate())
+                .exposeProposerInfo(saved.getExposeProposerInfo())
+                .exposeTargetInfo(saved.getExposeTargetInfo())
+                .publishedAt(saved.getPublishedAt())
+                .build();
+    }
+
     // 필수값 검증
     private void validateForPublish(PromotionManualPublishRequest request) {
         if (!hasText(request.getTitle())
@@ -165,6 +242,20 @@ public class PromotionService {
         }
     }
 
+    // 필수값 검증 (재게시 용)
+    private void validateForPublishEntity(Post p) {
+        if (!hasText(p.getTitle()) || !hasText(p.getTarget())
+                || !hasText(p.getBenefit()) || !hasText(p.getCondition())
+                || !hasText(p.getContent())
+                || p.getStartDate() == null || p.getEndDate() == null
+                || p.getExposureEndDate() == null) {
+            throw new GeneralException(ErrorStatus.REQUIRED_FIELD_MISSING);
+        }
+        if (p.getEndDate().isBefore(p.getStartDate())) {
+            throw new GeneralException(ErrorStatus.DATE_RANGE_INVALID);
+        }
+    }
+
     // 임시 저장을 위해서는 최소 1개 이상의 필드가 작성돼야 함
     private void validateHasAnyDraftField(PromotionDraftSaveRequest request) {
         boolean hasAny =
@@ -183,20 +274,47 @@ public class PromotionService {
 
     }
 
-    // 작성한 부분만 업데이트
-    private void applyPatch(Post post, PromotionDraftSaveRequest request) {
-        if (hasText(request.getTitle())) post.setTitle(request.getTitle());
-        if (hasText(request.getTarget())) post.setTarget(request.getTarget());
-        if (hasText(request.getBenefit())) post.setBenefit(request.getBenefit());
-        if (hasText(request.getCondition())) post.setCondition(request.getCondition());
-        if (hasText(request.getContent())) post.setContent(request.getContent());
+    // 수정 사항 반영 공통 코드
+    private void applyPatchCore(
+            Post post,
+            String title, String target,
+            LocalDate startDate, LocalDate endDate,
+            String benefit, String condition, String content,
+            LocalDate exposureEndDate,
+            Boolean exposeProposerInfo, Boolean exposeTargetInfo
+    ) {
+        if (hasText(title)) post.setTitle(title);
+        if (hasText(target)) post.setTarget(target);
+        if (hasText(benefit)) post.setBenefit(benefit);
+        if (hasText(condition)) post.setCondition(condition);
+        if (hasText(content)) post.setContent(content);
 
-        if (request.getStartDate() != null) post.setStartDate(request.getStartDate());
-        if (request.getEndDate() != null) post.setEndDate(request.getEndDate());
-        if (request.getExposureEndDate() != null) post.setExposureEndDate(request.getExposureEndDate());
+        if (startDate != null) post.setStartDate(startDate);
+        if (endDate != null) post.setEndDate(endDate);
+        if (exposureEndDate != null) post.setExposureEndDate(exposureEndDate);
 
-        if (request.getExposeProposerInfo() != null) post.setExposeProposerInfo(request.getExposeProposerInfo());
-        if (request.getExposeTargetInfo() != null) post.setExposeTargetInfo(request.getExposeTargetInfo());
+        if (exposeProposerInfo != null) post.setExposeProposerInfo(exposeProposerInfo);
+        if (exposeTargetInfo != null) post.setExposeTargetInfo(exposeTargetInfo);
+    }
+
+    // draft DTO
+    private void applyPatch(Post post, PromotionDraftSaveRequest r) {
+        applyPatchCore(post,
+                r.getTitle(), r.getTarget(),
+                r.getStartDate(), r.getEndDate(),
+                r.getBenefit(), r.getCondition(), r.getContent(),
+                r.getExposureEndDate(),
+                r.getExposeProposerInfo(), r.getExposeTargetInfo());
+    }
+
+    // 재수정 즉시 게시 DTO
+    private void applyPatch(Post post, PromotionManualPublishRequest r) {
+        applyPatchCore(post,
+                r.getTitle(), r.getTarget(),
+                r.getStartDate(), r.getEndDate(),
+                r.getBenefit(), r.getCondition(), r.getContent(),
+                r.getExposureEndDate(),
+                r.getExposeProposerInfo(), r.getExposeTargetInfo());
     }
 
     private void validateOptionalDateRange(LocalDate start, LocalDate end) {

--- a/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
@@ -9,6 +9,7 @@ import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.posts.repository.PostRepository;
 import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
+import com.itzi.itzi.promotion.dto.response.PromotionDeleteResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionDraftSaveResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionEditViewResponse;
 import com.itzi.itzi.promotion.dto.response.PromotionManualPublishResponse;
@@ -194,6 +195,28 @@ public class PromotionService {
 
         Post saved = postRepository.save(post);
         return buildPublishResponse(saved);
+    }
+
+    // 제휴 게시글 삭제하기
+    @Transactional
+    public PromotionDeleteResponse delete(Long postId) {
+
+        Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        // 게시된 글만 삭제 가능
+        if (post.getStatus() != Status.PUBLISHED) {
+            throw new GeneralException(ErrorStatus.CANNOT_DELETE_POST);
+        }
+
+        post.setStatus(Status.DELETED);
+        postRepository.save(post);
+
+        return new PromotionDeleteResponse(
+                post.getPostId(),
+                Type.RECRUITING,
+                post.getStatus()
+
+        );
     }
 
     private PromotionManualPublishResponse buildPublishResponse(Post saved) {


### PR DESCRIPTION
✨ Description
제휴 게시글 조회
Fixes #12 

📌 구현 내용
 - [x] 제휴 진행하기 게시글 수동 작성
 - POST	`/promotion`
- [x]  제휴 게시글 임시 저장 (최초/수정)
-  POST	`/promotion/draft`
- [x] 게시글 업로드
- PATCH	`/promotion/{postId}/publish`
- [x] 작성된 게시글 삭제 (status = PUBLISHED)
- DELETE `/promotion/{postId}`
- [x] 게시된 글 재수정 및 저장
- GET	`/promotion/{postId}/edit`
- PATCH	`/promotion/postId}/republish`