### PR TITLE
✨ Feat: 제휴 홍보 게시글 조회

### DIFF
--- a/src/main/java/com/itzi/itzi/global/api/code/ErrorStatus.java
+++ b/src/main/java/com/itzi/itzi/global/api/code/ErrorStatus.java
@@ -14,6 +14,7 @@ public enum ErrorStatus implements BaseErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "E-400-02", "요청 값이 올바르지 않습니다."),
     REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "E-400-03", "필수 입력 항목이 누락되었습니다."),
     DATE_RANGE_INVALID(HttpStatus.BAD_REQUEST, "E-400-04", "종료일은 시작일보다 빠를 수 없습니다."),
+    INVALID_TYPE(HttpStatus.BAD_REQUEST, "E-400-05", "잘못된 게시글 타입입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "E-404", "대상을 찾을 수 없습니다."),
     ALREADY_PUBLISHED(HttpStatus.CONFLICT, "E-409-01", "이미 게시된 글입니다."),
     CANNOT_DELETE_POST(HttpStatus.CONFLICT, "E-409-02", "해당 상태의 글은 삭제할 수 없습니다."),

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -2,6 +2,7 @@ package com.itzi.itzi.promotion.controller;
 
 import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
+import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
 import com.itzi.itzi.promotion.dto.response.*;
@@ -9,6 +10,8 @@ import com.itzi.itzi.promotion.service.PromotionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/promotion")
@@ -77,6 +80,14 @@ public class PromotionController {
         PromotionDeleteResponse response = promotionService.delete(postId);
         return ApiResponse.of(SuccessStatus._OK, response);
 
+    }
+
+    // 내가 작성한 제휴 홍보 게시글 목록 조회
+    @GetMapping("/mine")
+    public ApiResponse<List<PromotionListResponse>> getMyPromotionsList(@RequestParam Type type) {
+
+        List<PromotionListResponse> response = promotionService.getMyPromotionsList(type);
+        return ApiResponse.of(SuccessStatus._OK, response);
     }
 
 }

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -90,4 +90,10 @@ public class PromotionController {
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 
+    // 게시된 제휴 홍보글 단건 조회
+    @GetMapping("/{postId}")
+    public ApiResponse<PromotionDetailResponse> getPromotionDetail(@PathVariable Long postId) {
+        PromotionDetailResponse response = promotionService.getPromotionDetail(postId);
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
 }

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -2,6 +2,7 @@ package com.itzi.itzi.promotion.controller;
 
 import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
+import com.itzi.itzi.posts.domain.OrderBy;
 import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.promotion.dto.request.PromotionDraftSaveRequest;
 import com.itzi.itzi.promotion.dto.request.PromotionManualPublishRequest;
@@ -78,6 +79,17 @@ public class PromotionController {
     public ApiResponse<PromotionDeleteResponse> delete(@PathVariable Long postId) {
 
         PromotionDeleteResponse response = promotionService.delete(postId);
+        return ApiResponse.of(SuccessStatus._OK, response);
+
+    }
+
+    // 모든 사용자가 작성한 제휴 홍보 게시글 목록 조회
+    @GetMapping("/all")
+    public ApiResponse<List<PromotionListResponse>> getAllPromotionList(
+            @RequestParam Type type,
+            @RequestParam(defaultValue = "CLOSING") OrderBy orderBy
+    ) {
+        List<PromotionListResponse> response = promotionService.getAllPromotionList(type, orderBy);
         return ApiResponse.of(SuccessStatus._OK, response);
 
     }

--- a/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionDetailResponse.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionDetailResponse.java
@@ -1,0 +1,36 @@
+package com.itzi.itzi.promotion.dto.response;
+
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionDetailResponse {
+
+    private Long postId;
+    private Long userId;
+
+    private LocalDate exposureEndDate;
+    // 카테고리 추가 필요
+    private Long bookmarkCount;
+
+    private Type type;
+    private Status status;
+
+    private String postImage;
+    private String title;
+    private String target;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String benefit;
+    private String condition;
+    private String content;
+
+    // 작성자 정보 블럭 추가 필요
+}

--- a/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionListResponse.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionListResponse.java
@@ -1,0 +1,31 @@
+package com.itzi.itzi.promotion.dto.response;
+
+import com.itzi.itzi.posts.domain.Status;
+import com.itzi.itzi.posts.domain.Type;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionListResponse {
+
+    private Long postId;
+    private Long userId;
+    private Type type;
+    private Status status;
+
+    private Long bookmarkCount;
+    private LocalDate exposureEndDate;
+
+    private String postImage;
+    private String title;
+    private String target;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String benefit;
+
+}

--- a/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
@@ -261,6 +261,36 @@ public class PromotionService {
                 .toList();
     }
 
+    // 게시된 제휴 홍보글 단건 조회
+    @Transactional(readOnly = true)
+    public PromotionDetailResponse getPromotionDetail(Long postId) {
+
+        // 존재하는 게시글인지 확인
+        Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        // type이 PROMOTION인지 검증
+        if (post.getType() != Type.PROMOTION) {
+            throw new GeneralException(ErrorStatus.INVALID_TYPE, "해당 게시글은 제휴 홍보글이 아닙니다.");
+        }
+
+        return PromotionDetailResponse.builder()
+                .userId(1L)                     // userId는 1로 고정
+                .postId(post.getPostId())
+                .type(post.getType())
+                .status(post.getStatus())
+                .exposureEndDate(post.getExposureEndDate())
+                .bookmarkCount(post.getBookmarkCount())
+                .postImage(post.getPostImage())
+                .title(post.getTitle())
+                .target(post.getTarget())
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
+                .benefit(post.getBenefit())
+                .condition(post.getCondition())
+                .content(post.getContent())
+                .build();
+    }
+
     private PromotionManualPublishResponse buildPublishResponse(Post saved) {
         return PromotionManualPublishResponse.builder()
                 .type(saved.getType())

--- a/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
@@ -20,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -248,6 +249,18 @@ public class PromotionService {
         );
     }
 
+    // 내가 작성한 제휴 홍보 게시글 카드뷰 조회
+    @Transactional(readOnly = true)
+    public List<PromotionListResponse> getMyPromotionsList(Type type) {
+        Long FIXED_USER_ID = 1L;
+        List<Status> statuses = List.of(Status.DRAFT, Status.PUBLISHED);
+
+        return postRepository.findByUserIdAndTypeAndStatusIn(FIXED_USER_ID, type, statuses)
+                .stream()
+                .map(this::toListResponse)
+                .toList();
+    }
+
     private PromotionManualPublishResponse buildPublishResponse(Post saved) {
         return PromotionManualPublishResponse.builder()
                 .type(saved.getType())
@@ -390,6 +403,23 @@ public class PromotionService {
         } catch (IOException e) {
             throw new GeneralException(ErrorStatus.INTERNAL_ERROR, "이미지 업로드에 실패했습니다.");
         }
+    }
+
+    private PromotionListResponse toListResponse(Post post) {
+        return PromotionListResponse.builder()
+                .postId(post.getPostId())
+                .userId(post.getUserId())
+                .type(post.getType())
+                .status(post.getStatus())
+                .bookmarkCount(post.getBookmarkCount())
+                .exposureEndDate(post.getExposureEndDate())
+                .postImage(post.getPostImage())
+                .title(post.getTitle())
+                .target(post.getTarget())
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
+                .benefit(post.getBenefit())
+                .build();
     }
 
 }


### PR DESCRIPTION
## ✨ Description
> 제휴 홍보 게시글 조회
Fixes #13 

## 📌 구현 내용

- [x] 내 글 목록: GET `/promotion/mine?type=PROMOTION`
- post 엔티티에 userId 컬럼 추가
- userId는 1로 고정
- [x] 내 글 상세: GET `/promotion/{postId}`
- status가 DRAFT, PUBLISHED일 경우 조회
- [x] 모든 사용자가 작성한 게시글 조회 구현 GET `/promotion/all?type=PROMOTION` (status : `PUBLISHED`)
- [x] 모든 사용자가 작성한 게시글 필터링 조회 구현 
- 마감임박순 / 최신순 / 오래된순 / 인기순

### 참고 사항
- 모든 사용자가 작성한 게시글 조회는 추후에 **category** 필터링 추가 구현 필요
- 제휴 게시글 단건 상세 조회 기능에 **매장/사용자** 정보 추가 필요