### PR TITLE
✨ Feat: 제휴 모집 게시글 조회 기능 개선 (store 정보 포함, 필터링 기능)

### DIFF
--- a/src/main/java/com/itzi/itzi/auth/domain/OrgProfile.java
+++ b/src/main/java/com/itzi/itzi/auth/domain/OrgProfile.java
@@ -50,6 +50,10 @@ public class OrgProfile {
     @Column(length = 100)
     private String intro;
 
+    // 별점
+    @Column
+    private Integer rating;
+
     // 키워드 (최대 5개까지 사용자가 입력)
     /* @ElementCollection : Enum 값을 별도 테이블에 저장
        @CollectionTable : 부모 테이블의 PK를 FK로 가지는 연결 테이블 생성 */

--- a/src/main/java/com/itzi/itzi/posts/domain/Post.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/Post.java
@@ -1,5 +1,6 @@
 package com.itzi.itzi.posts.domain;
 
+import com.itzi.itzi.auth.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -20,9 +21,9 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postId;
 
-    // 추후에 FK로 수정
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "post_type")

--- a/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
+++ b/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
@@ -5,15 +5,18 @@ import com.itzi.itzi.posts.domain.Status;
 import com.itzi.itzi.posts.domain.Type;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 내 글 + 타입 + 상태 필터
-    List<Post> findByUserIdAndTypeAndStatusIn(
+    List<Post> findByUser_UserIdAndTypeAndStatusIn(
             Long userId,
             Type type,
             Collection<Status> statuses
@@ -28,4 +31,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     );
 
 
+    /*
+     1. Post 엔티티와 작성자(User)를 반드시 fetch join 으로 즉시 로딩
+     2. 작성자(User)와 연결된 OrgProfile, Store 정보를 left join 으로 함께 패치
+     */
+    @Query("""
+      select p 
+      from Post p 
+      join fetch p.user u 
+      left join OrgProfile op on op.user = u
+      left join Store s on s.user = u
+      where p.postId = :postId and p.type = :type
+    """)
+    Optional<Post> findRecruitingDetailWithAuthor(@Param("postId") Long postId,
+                                                  @Param("type") Type type);
 }

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -79,7 +79,7 @@ public class RecruitingController {
     // 내가 작성한 게시글 전체 조회 (userId = 1)
     @GetMapping("/mine")
     public ApiResponse<List<RecruitingListResponse>> getMyRecruitingList(
-            @RequestParam(defaultValue = "RECRUITING") Type type
+            @RequestParam Type type
     ) {
         List<RecruitingListResponse> response = recruitService.getMyRecruitingList(type);
         return ApiResponse.of(SuccessStatus._OK, response);
@@ -89,9 +89,10 @@ public class RecruitingController {
     @GetMapping("/all")
     public ApiResponse<List<RecruitingListResponse>> getAllRecruitingList(
             @RequestParam(defaultValue = "RECRUITING") Type type,
-            @RequestParam(defaultValue = "CLOSING") OrderBy orderBy
+            @RequestParam(defaultValue = "CLOSING") OrderBy orderBy,
+            @RequestParam(required = false) List<String> filters
     ) {
-        List<RecruitingListResponse> responses = recruitService.getAllRecruitingList(type, orderBy);
+        List<RecruitingListResponse> responses = recruitService.getAllRecruitingList(type, orderBy, filters);
         return ApiResponse.of(SuccessStatus._OK, responses);
     }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -78,21 +78,18 @@ public class RecruitingController {
 
     // 내가 작성한 게시글 전체 조회 (userId = 1)
     @GetMapping("/mine")
-    public ApiResponse<List<RecruitingListResponse>> getMyRecruitingList(
-            @RequestParam Type type
-    ) {
-        List<RecruitingListResponse> response = recruitService.getMyRecruitingList(type);
+    public ApiResponse<List<RecruitingListResponse>> getMyRecruitingList() {
+        List<RecruitingListResponse> response = recruitService.getMyRecruitingList();
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 
     // 모든 사용자가 작성한 제휴 모집글 조회
     @GetMapping("/all")
     public ApiResponse<List<RecruitingListResponse>> getAllRecruitingList(
-            @RequestParam(defaultValue = "RECRUITING") Type type,
             @RequestParam(defaultValue = "CLOSING") OrderBy orderBy,
             @RequestParam(required = false) List<String> filters
     ) {
-        List<RecruitingListResponse> responses = recruitService.getAllRecruitingList(type, orderBy, filters);
+        List<RecruitingListResponse> responses = recruitService.getAllRecruitingList(orderBy, filters);
         return ApiResponse.of(SuccessStatus._OK, responses);
     }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/dto/response/AuthorSummaryResponse.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/response/AuthorSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.itzi.itzi.recruitings.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorSummaryResponse {
+
+    private String image;
+    private Integer rating;
+    private String name;
+    private String info;
+    private Set<String> keywords;
+
+    private String schoolName;
+    private String unitName;
+    private String phone;
+    private String address;
+    private String ownerName;
+    private String linkUrl;
+
+}

--- a/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingDetailResponse.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/response/RecruitingDetailResponse.java
@@ -1,5 +1,6 @@
 package com.itzi.itzi.recruitings.dto.response;
 
+import com.itzi.itzi.auth.domain.Category;
 import com.itzi.itzi.posts.domain.Status;
 import com.itzi.itzi.posts.domain.Type;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 @Getter
 @Builder
@@ -21,7 +23,8 @@ public class RecruitingDetailResponse {
     private LocalDate exposureEndDate;
     private Long bookmarkCount;
 
-    // 카테고리 추가 필요
+    // 카테고리
+    private Category category;          // FOOD, FASHION, BEAUTY, HEALTH, BOOK, LIVING, HOSPITAL, IT, TRANSPORTATION, ETC
 
     private Type type;                  // RECRUITING, PROMOTION
     private Status status;              // DRAFT, PUBLISHED
@@ -41,6 +44,7 @@ public class RecruitingDetailResponse {
 
     private String content;
 
-    // 작성자 정보 블럭 추가 필요
+    // 작성자 정보 블럭
+    private Object author;
 
 }

--- a/src/main/java/com/itzi/itzi/recruitings/dto/response/StoreSummaryResponse.java
+++ b/src/main/java/com/itzi/itzi/recruitings/dto/response/StoreSummaryResponse.java
@@ -1,0 +1,30 @@
+package com.itzi.itzi.recruitings.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreSummaryResponse {
+
+    private String image;
+    private Integer rating;
+    private String name;
+    private String info;
+    private Set<String> keywords;
+
+    private String category;
+    private String operatingHours;
+    private String phone;
+    private String address;
+    private String ownerName;
+    private String linkUrl;
+
+
+}

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -521,9 +521,10 @@ public class RecruitService {
 
     // 내가 작성한 게시글 전체 리스트 조회 (userId = 1 고정)
     @Transactional(readOnly = true)
-    public List<RecruitingListResponse> getMyRecruitingList(Type type) {
+    public List<RecruitingListResponse> getMyRecruitingList() {
         Long FIXED_USER_ID = 1L;
         List<Status> statuses = List.of(Status.DRAFT, Status.PUBLISHED);
+        Type type = Type.RECRUITING;
 
         return postRepository.findByUser_UserIdAndTypeAndStatusIn(FIXED_USER_ID, type, statuses)
                 .stream()
@@ -533,8 +534,9 @@ public class RecruitService {
 
     // 모든 사용자가 작성한 제휴 모집글 조회
     @Transactional(readOnly = true)
-    public List<RecruitingListResponse> getAllRecruitingList(Type type, OrderBy orderBy, List<String> filters) {
+    public List<RecruitingListResponse> getAllRecruitingList(OrderBy orderBy, List<String> filters) {
         Status status = Status.PUBLISHED;           // 게시된 게시물만 조회
+        Type type = Type.RECRUITING;
 
         List<Post> posts = new ArrayList<>();
 

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -532,7 +533,7 @@ public class RecruitService {
 
     // 모든 사용자가 작성한 제휴 모집글 조회
     @Transactional(readOnly = true)
-    public List<RecruitingListResponse> getAllRecruitingList(Type type, OrderBy orderBy) {
+    public List<RecruitingListResponse> getAllRecruitingList(Type type, OrderBy orderBy, List<String> filters) {
         Status status = Status.PUBLISHED;           // 게시된 게시물만 조회
 
         List<Post> posts = new ArrayList<>();
@@ -565,9 +566,15 @@ public class RecruitService {
                         type, status, Sort.by(Sort.Direction.ASC, "publishedAt"));
             }
         }
+
+        // 필터링 (기본값: 전체 조회)
+        if (filters != null && !filters.isEmpty()) {
+            posts = posts.stream()
+                    .filter(post -> filters.stream().anyMatch(filter -> post.getBenefit().contains(filter)))
+                    .collect(Collectors.toList());
+        }
         return posts.stream().map(this::toListResponse).toList();
     }
-
 
     private RecruitingListResponse toListResponse(Post post) {
         return RecruitingListResponse.builder()

--- a/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
+++ b/src/main/java/com/itzi/itzi/recruitings/service/RecruitService.java
@@ -2,6 +2,11 @@ package com.itzi.itzi.recruitings.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itzi.itzi.auth.domain.OrgProfile;
+import com.itzi.itzi.auth.domain.OrgType;
+import com.itzi.itzi.auth.domain.User;
+import com.itzi.itzi.recruitings.dto.response.AuthorSummaryResponse;
+import com.itzi.itzi.auth.repository.UserRepository;
 import com.itzi.itzi.global.api.code.ErrorStatus;
 import com.itzi.itzi.global.exception.GeneralException;
 import com.itzi.itzi.global.s3.S3Service;
@@ -13,6 +18,7 @@ import com.itzi.itzi.posts.repository.PostRepository;
 import com.itzi.itzi.recruitings.dto.request.RecruitingAiGenerateRequest;
 import com.itzi.itzi.recruitings.dto.request.RecruitingDraftSaveRequest;
 import com.itzi.itzi.recruitings.dto.response.*;
+import com.itzi.itzi.store.domain.Store;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,6 +46,7 @@ import java.util.regex.Pattern;
 public class RecruitService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
     private final S3Service s3Service;
 
     @Value("${gemini.api.key}")
@@ -61,8 +68,13 @@ public class RecruitService {
         String endpoint = GEMINI_ENDPOINT + "?key=" + apiKey;
         String content = callGemini(endpoint, prompt);
 
+        // 2. Fetch the User entity using the userId
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다: " + userId));
+
         // 4. 이미지를 제외한 엔티티 구성
         Post entity = Post.builder()
+                        .user(user)
                         .type(Type.RECRUITING)
                         .title(request.getTitle().trim())
                         .target(request.getTarget().trim())
@@ -464,11 +476,27 @@ public class RecruitService {
     public RecruitingDetailResponse getRecruitingDetail(Long postId) {
 
         // 존재하는 게시글인지 확인
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findRecruitingDetailWithAuthor(postId, Type.RECRUITING)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
 
+        User author = post.getUser();
+
+        // 작성자 요약 블럭
+        OrgProfile org = author.getOrgProfile();
+        Store store = author.getStore();
+
+        // 작성자 타입에 따라 다른 요약 블럭을 생성
+        Object authorSummary;
+        if (org != null && org.getOrgType() == OrgType.STORE) {
+            // OrgType이 STORE일 경우, buildStoreSummary 메서드 사용
+            authorSummary = buildStoreSummary(store);
+        } else {
+            // 그 외의 경우, buildAuthorSummary 메서드 사용
+            authorSummary = buildAuthorSummary(author, org);
+        }
+
         return RecruitingDetailResponse.builder()
-                .userId(1L)                     // userId는 1로 고정
+                .userId(author.getUserId())
                 .postId(post.getPostId())
                 .type(post.getType())
                 .status(post.getStatus())
@@ -486,6 +514,7 @@ public class RecruitService {
                 .conditionNegotiable(post.isConditionNegotiable())
                 .postImageUrl(post.getPostImage())
                 .content(post.getContent())
+                .author(authorSummary)
                 .build();
     }
 
@@ -495,7 +524,7 @@ public class RecruitService {
         Long FIXED_USER_ID = 1L;
         List<Status> statuses = List.of(Status.DRAFT, Status.PUBLISHED);
 
-        return postRepository.findByUserIdAndTypeAndStatusIn(FIXED_USER_ID, type, statuses)
+        return postRepository.findByUser_UserIdAndTypeAndStatusIn(FIXED_USER_ID, type, statuses)
                 .stream()
                 .map(this::toListResponse)
                 .toList();
@@ -543,7 +572,7 @@ public class RecruitService {
     private RecruitingListResponse toListResponse(Post post) {
         return RecruitingListResponse.builder()
                 .postId(post.getPostId())
-                .userId(post.getUserId())
+                .userId(post.getUser().getUserId())
                 .type(post.getType())
                 .status(post.getStatus())
                 .exposureEndDate(post.getExposureEndDate())
@@ -559,4 +588,39 @@ public class RecruitService {
                 .benefitNegotiable(post.isBenefitNegotiable())
                 .build();
     }
+
+    // 일반 작성자/조직의 요약 정보 생성
+    private AuthorSummaryResponse buildAuthorSummary(User author, OrgProfile org) {
+        return AuthorSummaryResponse.builder()
+                .image(author.getProfileImage())
+                .rating(author.getOrgProfile().getRating())
+                .name(author.getProfileName())
+                .info(org != null ? org.getIntro() : null)
+                .keywords(org != null ? org.getKeywords() : null)
+                .schoolName(org.getSchoolName())
+                .unitName(org.getUnitName())
+                .phone(org != null ? org.getPhone() : null)
+                .address(org != null ? org.getAddress() : null)
+                .ownerName(org != null ? org.getOwnerName() : null)
+                .linkUrl(org != null ? org.getLinkUrl() : null)
+                .build();
+    }
+
+    // 상점의 요약 정보 생성
+    private StoreSummaryResponse buildStoreSummary(Store store) {
+        return StoreSummaryResponse.builder()
+                .image(store.getStoreImage())
+                .rating(store.getRating())
+                .name(store.getName())
+                .info(store.getInfo())
+                .keywords(store.getKeywords())
+                .category(store.getCategory().name())
+                .operatingHours(store.getOperatingHours())
+                .phone(store.getPhone())
+                .address(store.getAddress())
+                .ownerName(store.getOwnerName())
+                .linkUrl(store.getLinkUrl())
+                .build();
+    }
+
 }


### PR DESCRIPTION
## ✨ Description
> 제휴 모집 게시글 조회 기능 개선 (store 정보 포함, 필터링 기능)

## 📝 상세 내용
- 단건 조회 (GET `/recruiting/{postId}`) 응답에 store 정보(id, name, address, …) 포함
- 전체 조회 (GET `/recruiting/all/type=RECRUITING`) 필터링 조건 추가

## 📌 구현 내용

- [x] 단건 조회 API 응답 DTO에 store 정보 추가
- [x] Service/Repository에서 store 정보 매핑
- [x] 제휴 게시글 전체 조회 시 필터링 기능 추가
- 기본값 : 전체 조회

### 🔎 참고 사항
- URI에서 Type 파라미터를 변경하였습니다.
- 변경 전 :  /recruiting/mine?type=RECRUITING
- 변경 후 : /recruiting/mine