### PR TITLE
✨ Feature - 제휴 게시글 작성 로직 개선

### DIFF
--- a/src/main/java/com/itzi/itzi/agreement/domain/Agreement.java
+++ b/src/main/java/com/itzi/itzi/agreement/domain/Agreement.java
@@ -1,0 +1,102 @@
+package com.itzi.itzi.agreement.domain;
+
+import com.itzi.itzi.auth.domain.User;
+import com.itzi.itzi.posts.domain.Post;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Agreement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "agreement_id", nullable = false, unique = true)
+    private Long agreementId;
+
+    @ManyToOne
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @ManyToOne
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    // 제휴 제안자
+    @Column(name = "sender_name", nullable = false)
+    private String senderName;
+
+    // 제휴 대상자
+    @Column(name = "receiver_name", nullable = false)
+    private String receiverName;
+
+    // 제 1조(목적)
+    @Column
+    private String purpose;
+
+    // 제 2조(대상 및 기간)
+    @Column(name = "target_period")
+    private String targetPeriod;
+
+    // 제 3조(혜택 및 조건)
+    @Column(name = "benefit_condition")
+    private String benefitCondition;
+
+    //제 4조(역할 및 의무)
+    @Column
+    private String role;
+
+    // 제 5조(효력 및 해지)
+    @Column
+    private String effect;
+
+    // 제 6조(기타)
+    @Column
+    private String etc;
+
+    // 제휴업무 협약서(AI 변환 글 : 작성 전 null)
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    // 문서 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 엔티티가 db에 반영되기 직전에 자동으로 값이 채워짐! --> null 값 방지
+
+    // 자동으로 시간 설정
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 자동으로 시간 업데이트
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @OneToOne(mappedBy = "agreement", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Post post;
+
+    public void setPost(Post post) {
+        this.post = post;
+        if (post.getAgreement() != this) {
+            post.setAgreement(this);
+        }
+    }
+}

--- a/src/main/java/com/itzi/itzi/agreement/domain/Status.java
+++ b/src/main/java/com/itzi/itzi/agreement/domain/Status.java
@@ -1,0 +1,11 @@
+package com.itzi.itzi.agreement.domain;
+
+public enum Status {
+    DRAFT,
+    GENERATED,
+    SENT,
+    SIGNED_SENDER,
+    SIGNED_RECEIVER,
+    SIGNED_ALL,
+    APPROVED
+}

--- a/src/main/java/com/itzi/itzi/agreement/repository/AgreementRepository.java
+++ b/src/main/java/com/itzi/itzi/agreement/repository/AgreementRepository.java
@@ -1,0 +1,12 @@
+package com.itzi.itzi.agreement.repository;
+
+import com.itzi.itzi.agreement.domain.Agreement;
+import com.itzi.itzi.agreement.domain.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AgreementRepository extends JpaRepository<Agreement, Long> {
+
+    List<Agreement> findByStatusAndPostIsNull(Status status);
+}

--- a/src/main/java/com/itzi/itzi/agreement/repository/DocsRepository.java
+++ b/src/main/java/com/itzi/itzi/agreement/repository/DocsRepository.java
@@ -1,0 +1,12 @@
+package com.itzi.itzi.agreement.repository;
+
+import com.itzi.itzi.agreement.domain.Docs;
+import com.itzi.itzi.agreement.domain.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DocsRepository extends JpaRepository<Docs, Long> {
+
+    List<Docs> findByStatusAndPostIsNull(Status status);
+}

--- a/src/main/java/com/itzi/itzi/global/api/code/ErrorStatus.java
+++ b/src/main/java/com/itzi/itzi/global/api/code/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_SENT(HttpStatus.CONFLICT, "E-409-03", "이미 제휴 요청이 전달되었습니다."),
     INVALID_STATUS(HttpStatus.CONFLICT, "E-409-04", "현재 상태에서는 수행할 수 없는 요청입니다."),
     NOT_ALLOWED_DELETE(HttpStatus.CONFLICT, "E-409-05", "삭제할 수 없는 상태의 제휴 요청입니다."),
+    POST_ALREADY_EXISTS(HttpStatus.CONFLICT, "E-409-06", "이미 제휴 홍보 게시글이 작성되었습니다."),
 
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E-500-99", "내부 서버 오류"),
 
@@ -57,4 +58,6 @@ public enum ErrorStatus implements BaseErrorCode {
                 .httpStatus(httpStatus)
                 .build();
     }
+
+
 }

--- a/src/main/java/com/itzi/itzi/posts/domain/Post.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/Post.java
@@ -1,6 +1,6 @@
 package com.itzi.itzi.posts.domain;
 
-import com.itzi.itzi.agreement.domain.Docs;
+import com.itzi.itzi.agreement.domain.Agreement;
 import com.itzi.itzi.auth.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -94,8 +94,8 @@ public class Post {
     private Boolean exposeTargetInfo;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "docs_id")
-    private Docs docs;
+    @JoinColumn(name = "agreement_id")
+    private Agreement agreement;
 
     @ManyToOne
     @JoinColumn(name = "sender_id")

--- a/src/main/java/com/itzi/itzi/posts/domain/Post.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/Post.java
@@ -1,5 +1,6 @@
 package com.itzi.itzi.posts.domain;
 
+import com.itzi.itzi.agreement.domain.Docs;
 import com.itzi.itzi.auth.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -91,5 +92,17 @@ public class Post {
     // 제휴 제안자, 대상자
     private Boolean exposeProposerInfo;
     private Boolean exposeTargetInfo;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "docs_id")
+    private Docs docs;
+
+    @ManyToOne
+    @JoinColumn(name = "sender_id")
+    private User sender;
+
+    @ManyToOne
+    @JoinColumn(name = "receiver_id")
+    private User receiver;
 
 }

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -1,5 +1,6 @@
 package com.itzi.itzi.promotion.controller;
 
+import com.itzi.itzi.agreement.domain.Docs;
 import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
 import com.itzi.itzi.posts.domain.OrderBy;
@@ -21,6 +22,13 @@ import java.util.List;
 public class PromotionController {
 
     private final PromotionService promotionService;
+
+    // 제휴 홍보 게시글을 맺을 수 있는 제휴 대상자 리스트 조회
+    @GetMapping("/available")
+    public ApiResponse<List<String>> getAvailableDocs() {
+        List<String> receiverNames  = promotionService.getAvailableDocs();
+        return ApiResponse.of(SuccessStatus._OK, receiverNames);
+    }
 
     // 제휴 게시글 수동 작성 후 업로드
     @PostMapping

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -25,11 +25,11 @@ public class PromotionController {
     // 제휴 게시글 수동 작성 후 업로드
     @PostMapping
     public ApiResponse<PromotionManualPublishResponse> promotionManualPublish(
+            @RequestParam(name = "docsId") Long docsId,
             @ModelAttribute PromotionManualPublishRequest request
     ){
 
-        Long fixedUserId = 1L;                 // 항상 1
-        PromotionManualPublishResponse response = promotionService.promotionManualPublish(fixedUserId, request);
+        PromotionManualPublishResponse response = promotionService.promotionManualPublish(docsId, request);
 
         return ApiResponse.of(SuccessStatus._OK, response);
     }

--- a/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/PromotionController.java
@@ -1,6 +1,5 @@
 package com.itzi.itzi.promotion.controller;
 
-import com.itzi.itzi.agreement.domain.Docs;
 import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
 import com.itzi.itzi.posts.domain.OrderBy;
@@ -25,19 +24,19 @@ public class PromotionController {
 
     // 제휴 홍보 게시글을 맺을 수 있는 제휴 대상자 리스트 조회
     @GetMapping("/available")
-    public ApiResponse<List<String>> getAvailableDocs() {
-        List<String> receiverNames  = promotionService.getAvailableDocs();
+    public ApiResponse<List<String>> getAvailableAgreements() {
+        List<String> receiverNames  = promotionService.getAvailableAgreement();
         return ApiResponse.of(SuccessStatus._OK, receiverNames);
     }
 
     // 제휴 게시글 수동 작성 후 업로드
     @PostMapping
     public ApiResponse<PromotionManualPublishResponse> promotionManualPublish(
-            @RequestParam(name = "docsId") Long docsId,
+            @RequestParam(name = "agreementId") Long agreementId,
             @ModelAttribute PromotionManualPublishRequest request
     ){
 
-        PromotionManualPublishResponse response = promotionService.promotionManualPublish(docsId, request);
+        PromotionManualPublishResponse response = promotionService.promotionManualPublish(agreementId, request);
 
         return ApiResponse.of(SuccessStatus._OK, response);
     }

--- a/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionManualPublishResponse.java
+++ b/src/main/java/com/itzi/itzi/promotion/dto/response/PromotionManualPublishResponse.java
@@ -19,6 +19,9 @@ public class PromotionManualPublishResponse {
     private Status status;
     private Long postId;
 
+    private String senderName;
+    private String receiverName;
+
     private String postImage;
     private String title;
     private String target;

--- a/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -37,6 +38,17 @@ public class PromotionService {
     private final PostRepository postRepository;
     private final S3Service s3Service;
     private final DocsRepository docsRepository;
+
+    // 제휴 홍보 게시글을 맺을 수 있는 제휴 대상자 리스트 조회
+    @Transactional(readOnly = true)
+    public List<String> getAvailableDocs() {
+        List<Docs> docsList = docsRepository.findByStatusAndPostIsNull(com.itzi.itzi.agreement.domain.Status.APPROVED);
+
+        return docsList.stream()
+                .map(Docs::getReceiverName) // Docs 객체에서 receiverName만 추출
+                .distinct() // 중복 제거
+                .collect(Collectors.toList());
+    }
 
     // 제휴 게시글 수동 작성 후 업로드
     @Transactional

--- a/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/PromotionService.java
@@ -1,7 +1,7 @@
 package com.itzi.itzi.promotion.service;
 
-import com.itzi.itzi.agreement.domain.Docs;
-import com.itzi.itzi.agreement.repository.DocsRepository;
+import com.itzi.itzi.agreement.domain.Agreement;
+import com.itzi.itzi.agreement.repository.AgreementRepository;
 import com.itzi.itzi.auth.domain.User;
 import com.itzi.itzi.global.api.code.ErrorStatus;
 import com.itzi.itzi.global.exception.GeneralException;
@@ -37,34 +37,34 @@ public class PromotionService {
 
     private final PostRepository postRepository;
     private final S3Service s3Service;
-    private final DocsRepository docsRepository;
+    private final AgreementRepository agreementRepository;
 
     // 제휴 홍보 게시글을 맺을 수 있는 제휴 대상자 리스트 조회
     @Transactional(readOnly = true)
-    public List<String> getAvailableDocs() {
-        List<Docs> docsList = docsRepository.findByStatusAndPostIsNull(com.itzi.itzi.agreement.domain.Status.APPROVED);
+    public List<String> getAvailableAgreement() {
+        List<Agreement> agreementList = agreementRepository.findByStatusAndPostIsNull(com.itzi.itzi.agreement.domain.Status.APPROVED);
 
-        return docsList.stream()
-                .map(Docs::getReceiverName) // Docs 객체에서 receiverName만 추출
+        return agreementList.stream()
+                .map(Agreement::getReceiverName) // Agreement 객체에서 receiverName만 추출
                 .distinct() // 중복 제거
                 .collect(Collectors.toList());
     }
 
     // 제휴 게시글 수동 작성 후 업로드
     @Transactional
-    public PromotionManualPublishResponse promotionManualPublish(Long docsId, PromotionManualPublishRequest request) {
+    public PromotionManualPublishResponse promotionManualPublish(Long agreementId, PromotionManualPublishRequest request) {
 
         // 0. 제휴 게시글을 맺을 수 있는 상태인지 검증 추가 필요
-        Docs docs = docsRepository.findById(docsId)
+        Agreement agreement = agreementRepository.findById(agreementId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PARTNERSHIP_NOT_FOUND));
 
-        // docs 협의 상태가 완료인 경우에만 제휴 홍보글 작성 가능
-        if (docs.getStatus() != com.itzi.itzi.agreement.domain.Status.APPROVED) {
+        // agreement 협의 상태가 완료인 경우에만 제휴 홍보글 작성 가능
+        if (agreement.getStatus() != com.itzi.itzi.agreement.domain.Status.APPROVED) {
             throw new GeneralException(ErrorStatus.INVALID_STATUS);
         }
 
-        // Docs에 연결된 Post가 이미 있는지 확인
-        if (docs.getPost() != null) {
+        // Agreement에 연결된 Post가 이미 있는지 확인
+        if (agreement.getPost() != null) {
             throw new GeneralException(ErrorStatus.POST_ALREADY_EXISTS);
         }
 
@@ -75,8 +75,8 @@ public class PromotionService {
         Post post = Post.builder()
                 .type(Type.PROMOTION)
                 .status(Status.PUBLISHED)
-                .sender(docs.getSender())
-                .receiver(docs.getReceiver())
+                .sender(agreement.getSender())
+                .receiver(agreement.getReceiver())
                 .title(request.getTitle())
                 .target(request.getTarget())
                 .benefit(request.getBenefit())
@@ -87,7 +87,7 @@ public class PromotionService {
                 .exposureEndDate(request.getExposureEndDate())
                 .exposeProposerInfo(Boolean.TRUE.equals(request.getExposeProposerInfo()))
                 .exposeTargetInfo(Boolean.TRUE.equals(request.getExposeTargetInfo()))
-                .docs(docs)
+                .agreement(agreement)
                 .publishedAt(LocalDateTime.now())
                 .build();
 
@@ -96,17 +96,17 @@ public class PromotionService {
 
         postRepository.save(post);
 
-        // partnership 엔티티에 Post 정보 업데이트 (양방향 관계)
-        docs.setPost(post);
-        docsRepository.save(docs);
+        // agreement 엔티티에 Post 정보 업데이트 (양방향 관계)
+        agreement.setPost(post);
+        agreementRepository.save(agreement);
 
         // 4. 응답 반환
         return PromotionManualPublishResponse.builder()
                 .type(post.getType())
                 .status(post.getStatus())
                 .postId(post.getPostId())
-                .senderName(docs.getSenderName())
-                .receiverName(docs.getReceiverName())
+                .senderName(agreement.getSenderName())
+                .receiverName(agreement.getReceiverName())
                 .postImage(post.getPostImage())
                 .title(post.getTitle())
                 .target(post.getTarget())


### PR DESCRIPTION
## ✨ Description
> 제휴 게시글 작성 로직 개선: 문의 완료 항목만 게시 가능하도록 로직 개선

## 📝 상세 내용
- `Docs` 테이블의 `status`가 '문의 완료' 상태인 항목에 대해서만 게시글을 작성할 수 있도록 로직을 수정
- 게시글 작성 시, 해당 `Agreement`의 **sender(제안자)**와 **receiver(제안받는 사람)** 정보를 게시글에 연결

## 📌 구현 내용

- [x] GET `/promotion/available` (게시글 작성 가능한 목록 조회) API 로직 구현
- [x] Docs 테이블에서 status가 **문의 완료**이고, Post에 연결되지 않은 목록을 조회
- 응답 DTO에 agreementId, sender, receiver 정보 포함.
- [x] POST `/promotion` (게시글 작성) API 로직 수정
- agreementId를 매개변수로 받아 해당 Agreement 엔티티를 조회.
- 조회한 Docs의 sender와 receiver를 게시글에 연결하고 저장
- [x] `Agreement` Entity, Repository 추가
