### PR TITLE
✨ Feat: 혜택 홍보 게시글 작성 및 업로드

### DIFF
--- a/src/main/java/com/itzi/itzi/promotion/controller/BenefitController.java
+++ b/src/main/java/com/itzi/itzi/promotion/controller/BenefitController.java
@@ -4,6 +4,7 @@ import com.itzi.itzi.global.api.code.SuccessStatus;
 import com.itzi.itzi.global.api.dto.ApiResponse;
 import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.posts.dto.request.PostDraftSaveRequest;
+import com.itzi.itzi.posts.dto.response.PostDeleteResponse;
 import com.itzi.itzi.posts.dto.response.PostDraftSaveResponse;
 import com.itzi.itzi.posts.dto.response.PostPublishResponse;
 import com.itzi.itzi.promotion.dto.request.BenefitGenerateAiRequest;
@@ -52,6 +53,13 @@ public class BenefitController {
     public ApiResponse<PostPublishResponse> publishBenefit(@PathVariable Long postId) {
         PostPublishResponse response = benefitService.publishBenefit(postId);
 
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    // 삭제하기
+    @DeleteMapping("/{postId}")
+    public ApiResponse<PostDeleteResponse> deleteBenefit(@PathVariable Long postId) {
+        PostDeleteResponse response = benefitService.deleteBenefit(postId);
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 

--- a/src/main/java/com/itzi/itzi/promotion/service/BenefitService.java
+++ b/src/main/java/com/itzi/itzi/promotion/service/BenefitService.java
@@ -10,6 +10,7 @@ import com.itzi.itzi.posts.domain.Post;
 import com.itzi.itzi.posts.domain.Status;
 import com.itzi.itzi.posts.domain.Type;
 import com.itzi.itzi.posts.dto.request.PostDraftSaveRequest;
+import com.itzi.itzi.posts.dto.response.PostDeleteResponse;
 import com.itzi.itzi.posts.dto.response.PostDraftSaveResponse;
 import com.itzi.itzi.posts.dto.response.PostPublishResponse;
 import com.itzi.itzi.posts.repository.PostRepository;
@@ -116,6 +117,22 @@ public class BenefitService {
         }
 
         return postService.pusblishPost(postId);
+    }
+
+    // 제휴 홍보 게시글 삭제하기
+    @Transactional
+    public PostDeleteResponse deleteBenefit(Long postId) {
+
+        // 1. 게시글 존재 여부 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        // 2. 게시글 타입 검증 : BENEFIT 타입만 삭제 가능
+        if (post.getType() != Type.BENEFIT) {
+            throw new GeneralException(ErrorStatus.INVALID_TYPE, "BENEFIT 타입의 게시물만 삭제할 수 있습니다.");
+        }
+
+        return postService.deletePost(postId);
     }
 
     private void validate(BenefitGenerateAiRequest request) {


### PR DESCRIPTION
## ✨ Description
> 혜택 홍보 게시글 구현
fixes #35 

## 📝 상세 내용
- 혜택 홍보 게시글 작성 후 상세 내용 AI 반환
- 임시 저장, 업로드, 삭제

## 📌 구현 내용
- [x] Post 도메인 - Type에 `BENEFIT` ENUM 값 추가
-  혜택 홍보 게시글 작성 후 상세 내용 AI 반환
- [x] request/response DTO 구현
- [x] Service, Controller 구현
- 임시 저장, 업로드, 삭제
- [x] Service, Controller 구현

### 🔎 참고 사항
- 임시저장, 업로드, 삭제는 Post DTO, Service 코드를 받아와 구현하였습니다.