### PR TITLE
✨ Feat: org_type 값에 따라 필터링 기능 구현

### DIFF
--- a/src/main/java/com/itzi/itzi/posts/domain/Post.java
+++ b/src/main/java/com/itzi/itzi/posts/domain/Post.java
@@ -2,6 +2,7 @@ package com.itzi.itzi.posts.domain;
 
 import com.itzi.itzi.agreement.domain.Agreement;
 import com.itzi.itzi.auth.domain.Category;
+import com.itzi.itzi.auth.domain.OrgProfile;
 import com.itzi.itzi.auth.domain.User;
 import com.itzi.itzi.partnership.domain.Partnership;
 import jakarta.persistence.*;
@@ -116,5 +117,9 @@ public class Post {
     @Enumerated(EnumType.STRING)
     @Column(name = "category")
     private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "org_id", nullable = false)
+    private OrgProfile orgProfile;
 
 }

--- a/src/main/java/com/itzi/itzi/posts/dto/response/PostListResponse.java
+++ b/src/main/java/com/itzi/itzi/posts/dto/response/PostListResponse.java
@@ -19,7 +19,7 @@ public class PostListResponse {
     private Long postId;
     private Long userId;
 
-    private Category category;
+    private String category;
     private Type type;
     private Status status;
 

--- a/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
+++ b/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
@@ -1,8 +1,11 @@
 package com.itzi.itzi.posts.repository;
 
+import com.itzi.itzi.auth.domain.OrgType;
 import com.itzi.itzi.posts.domain.Post;
 import com.itzi.itzi.posts.domain.Status;
 import com.itzi.itzi.posts.domain.Type;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -35,6 +38,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByTypeInAndStatusAndExposureEndDateGreaterThanEqual(
             List<Type> types, Status status, LocalDate today, Sort sort
     );
+
+    // OrgProfile의 OrgType에 따라 게시글을 필터링하여 페이징 조회
+    @Query("select p from Post p join p.user u join u.orgProfile o where o.orgType = :orgType")
+    Page<Post> findByUser_OrgProfile_OrgType(@Param("orgType") OrgType orgType, Pageable pageable);
 
 
     /*

--- a/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
+++ b/src/main/java/com/itzi/itzi/posts/repository/PostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,7 +17,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
 
     // 내 글 + 타입 + 상태 필터
     List<Post> findByUser_UserIdAndTypeAndStatusIn(

--- a/src/main/java/com/itzi/itzi/posts/service/PostService.java
+++ b/src/main/java/com/itzi/itzi/posts/service/PostService.java
@@ -315,7 +315,7 @@ public class PostService {
         return PostListResponse.builder()
                 .postId(post.getPostId())
                 .userId(post.getUser().getUserId())
-                .category(post.getCategory())
+                .category(post.getUser().getInterest().getDescription())
                 .type(post.getType())
                 .status(post.getStatus())
                 .exposureEndDate(post.getExposureEndDate())

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -87,22 +87,15 @@ public class RecruitingController {
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 
-    // 모든 사용자가 작성한 제휴 모집글 조회
-    @GetMapping("/all")
-    public ApiResponse<List<PostListResponse>> getAllRecruitingList(
-            @RequestParam(defaultValue = "CLOSING") OrderBy orderBy,
-            @RequestParam(required = false) List<String> filters
-    ) {
-        List<PostListResponse> responses = recruitService.getAllRecruitingList(orderBy, filters);
-        return ApiResponse.of(SuccessStatus._OK, responses);
-    }
-
+    // 모든 사용자가 작성한 게시글 리스트 조회
     @GetMapping()
-    public ApiResponse<Page<PostListResponse>> getPosts(
+    public ApiResponse<Page<PostListResponse>> getRecruitingUnified(
+            @RequestParam(defaultValue = "CLOSING") OrderBy orderBy,
+            @RequestParam(required = false) List<String> filters,
             @RequestParam(required = false, defaultValue = "전체") String orgType,
             @PageableDefault(size = 12, page = 0) Pageable pageable
     ) {
-        Page<PostListResponse> posts = recruitService.getPostsByOrgType(orgType, pageable);
-        return ApiResponse.of(SuccessStatus._OK, posts);
+        Page<PostListResponse> page = recruitService.getRecruiting(orderBy, filters, orgType, pageable);
+        return ApiResponse.of(SuccessStatus._OK, page);
     }
 }

--- a/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
+++ b/src/main/java/com/itzi/itzi/recruitings/controller/RecruitingController.java
@@ -11,6 +11,9 @@ import com.itzi.itzi.recruitings.dto.response.*;
 import com.itzi.itzi.recruitings.service.RecruitService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -92,5 +95,14 @@ public class RecruitingController {
     ) {
         List<PostListResponse> responses = recruitService.getAllRecruitingList(orderBy, filters);
         return ApiResponse.of(SuccessStatus._OK, responses);
+    }
+
+    @GetMapping()
+    public ApiResponse<Page<PostListResponse>> getPosts(
+            @RequestParam(required = false, defaultValue = "전체") String orgType,
+            @PageableDefault(size = 12, page = 0) Pageable pageable
+    ) {
+        Page<PostListResponse> posts = recruitService.getPostsByOrgType(orgType, pageable);
+        return ApiResponse.of(SuccessStatus._OK, posts);
     }
 }


### PR DESCRIPTION
## ✨ Description
> 작성자의 `org_type` 값에 따라 게시글 조회 시 필터링 기능을 구현
fixes #48 
## 📝 상세 내용
- org_type(매장, 학교, 학과, 동아리/소모임)에 따라 탭 클릭 시 해당 유형의 게시글만 조회 필터링 구현
- 기본값 : 전체

## 📌 구현 내용

- [x] org_type 필드를 기준으로 DB 조회 조건 추가
- [x] Service/Repository 계층에서 org_type 필터링 로직 구현
- [x] Controller API에 org_type 파라미터 추가 (기본값: 전체)

### 🔎 참고 사항
작성자 게시글 조회 시 필터링, orgType, 정렬 기능을 통합하였습니다.